### PR TITLE
Get player count when they join instead on tick

### DIFF
--- a/src/main/java/main/Interweave.java
+++ b/src/main/java/main/Interweave.java
@@ -39,8 +39,6 @@ public class Interweave implements DedicatedServerModInitializer {
 
     public static HashMap<String, String> mentionables;
 
-    private static int tick = 0;
-
     @Override
     public void onInitializeServer()  {
         settings = SettingsManager.getInstance().getSettings();
@@ -51,16 +49,6 @@ public class Interweave implements DedicatedServerModInitializer {
         } catch (LoginException | InterruptedException e) {
             e.printStackTrace();
         }
-
-        ServerTickCallback.EVENT.register(server -> {
-            tick++;
-            if (tick % 240 == 0) {
-                jda.getPresence().setActivity(Activity.of(Activity.ActivityType.DEFAULT, server.getCurrentPlayerCount() + "/" + server.getMaxPlayerCount()));
-                if (tick == 1201) {
-                    tick = 0;
-                }
-            }
-        });
     }
 
     private void initJDA(Settings settings) throws LoginException, InterruptedException {
@@ -216,4 +204,7 @@ public class Interweave implements DedicatedServerModInitializer {
         return mentionables;
     }
 
+    public static void setPlayers(int current, int max) {
+        jda.getPresence().setActivity(Activity.of(Activity.ActivityType.DEFAULT, current + "/" + max));
+    }
 }

--- a/src/main/java/mixin/MixinMinecraftServer.java
+++ b/src/main/java/mixin/MixinMinecraftServer.java
@@ -5,6 +5,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.WorldGenerationProgressListener;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -12,7 +13,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.UUID;
 
 @Mixin(MinecraftServer.class)
-public class MixinMinecraftServer {
+public abstract class MixinMinecraftServer {
+
+    @Shadow public abstract int getMaxPlayerCount();
 
     @Inject(at = @At("RETURN"), method = "sendSystemMessage")
     public void sendMessage(Text text, UUID uUID, CallbackInfo ci) {
@@ -22,6 +25,7 @@ public class MixinMinecraftServer {
     @Inject(at = @At("RETURN"), method = "prepareStartRegion")
     public void startServer(WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci) {
         Interweave.sendStartMessage();
+        Interweave.setPlayers(0, getMaxPlayerCount());
     }
 
     @Inject(at = @At("HEAD"), method = "shutdown")

--- a/src/main/java/mixin/MixinPlayerManager.java
+++ b/src/main/java/mixin/MixinPlayerManager.java
@@ -1,0 +1,31 @@
+package mixin;
+
+import main.Interweave;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(PlayerManager.class)
+public class MixinPlayerManager {
+    @Shadow @Final private List<ServerPlayerEntity> players;
+
+    @Shadow @Final protected int maxPlayers;
+
+    @Inject(at = @At("RETURN"), method = "onPlayerConnect")
+    public void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
+        Interweave.setPlayers(players.size(), maxPlayers);
+    }
+
+    @Inject(at = @At("RETURN"), method = "remove")
+    public void remove(ServerPlayerEntity player, CallbackInfo ci) {
+        Interweave.setPlayers(players.size(), maxPlayers);
+    }
+}

--- a/src/main/resources/interweave.mixin.json
+++ b/src/main/resources/interweave.mixin.json
@@ -3,7 +3,8 @@
   "package": "mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "MixinMinecraftServer"
+    "MixinMinecraftServer",
+    "MixinPlayerManager"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Optimizes it so it doesn't tick all the time, only updates it when a player actually joins or leaves.